### PR TITLE
feat: wire pnpm check contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write .",
     "test": "vitest",
     "test:e2e": "playwright test",
-    "check": "tsc -b && eslint . && vitest run"
+    "check": "tsc -b --noEmit && eslint . && prettier --check . && vitest run"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",


### PR DESCRIPTION
## Summary
- Update `pnpm check` to run `tsc -b --noEmit && eslint . && prettier --check . && vitest run` in that order
- Keep `pnpm test:e2e` intentionally outside `check` so the loop stays fast
- Lock in the PRD's Definition of Done: `pnpm check` is the single source of truth for "does this pass CI"

## Acceptance criteria
- [x] `pnpm check` runs `tsc --noEmit && eslint . && prettier --check . && vitest run` in that order
- [x] `pnpm check` exits 0 on a freshly cloned `chore/scaffolding`
- [x] `pnpm test:e2e` is not part of `check` and remains callable separately
- [ ] `pnpm dev` still loads the app with title `Mozaicon`
- [ ] `pnpm test:e2e` still passes the Chromium smoke test
- [x] `package.json` scripts expose at minimum: `dev`, `build`, `check`, `test`, `test:e2e`, `lint`, `format`

## Test plan
- `pnpm check` locally (passes: tsc, eslint, prettier, vitest — all green)
- CI will re-run `pnpm check` on the PR
- Manual verification of `pnpm dev` (title) and `pnpm test:e2e` (Chromium smoke) to be confirmed before merge

Closes #7