### PR TITLE
feat: data-driven canvas: splitAtom + ShapeRenderer + RectRenderer

### DIFF
--- a/src/features/canvas/CanvasStage.test.tsx
+++ b/src/features/canvas/CanvasStage.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { CanvasStage } from '@/features/canvas/CanvasStage'
+import { documentAtom } from '@/store/atoms/document'
+import { renderWithStore } from '@/test/renderWithStore'
+import type { Document } from '@/types/shapes'
+
+const seededDoc: Document = {
+  id: 'doc-test',
+  name: 'Test',
+  viewBox: [0, 0, 24, 24],
+  shapes: [
+    {
+      id: 'r1',
+      name: 'Rect 1',
+      visible: true,
+      locked: false,
+      type: 'rect',
+      x: 4,
+      y: 4,
+      width: 16,
+      height: 16,
+      fill: '#000',
+    },
+  ],
+}
+
+describe('CanvasStage', () => {
+  it('renders a <rect> with the seeded shape attributes', () => {
+    const { container } = renderWithStore(<CanvasStage />, (store) => {
+      store.set(documentAtom, seededDoc)
+    })
+
+    const rect = container.querySelector('rect')
+    expect(rect).not.toBeNull()
+    expect(rect?.getAttribute('x')).toBe('4')
+    expect(rect?.getAttribute('y')).toBe('4')
+    expect(rect?.getAttribute('width')).toBe('16')
+    expect(rect?.getAttribute('height')).toBe('16')
+    expect(rect?.getAttribute('fill')).toBe('#000')
+  })
+
+  it('renders the canvas with the document viewBox', () => {
+    const { container } = renderWithStore(<CanvasStage />, (store) => {
+      store.set(documentAtom, seededDoc)
+    })
+
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 24 24')
+  })
+
+  it('renders one <rect> per shape in the document', () => {
+    const doc: Document = {
+      ...seededDoc,
+      shapes: [
+        { ...seededDoc.shapes[0], id: 'r1' },
+        { ...seededDoc.shapes[0], id: 'r2', x: 10 },
+      ],
+    }
+    const { container } = renderWithStore(<CanvasStage />, (store) => {
+      store.set(documentAtom, doc)
+    })
+
+    expect(container.querySelectorAll('rect')).toHaveLength(2)
+  })
+})

--- a/src/features/canvas/CanvasStage.tsx
+++ b/src/features/canvas/CanvasStage.tsx
@@ -1,21 +1,35 @@
 import { useAtomValue } from 'jotai'
+import { selectAtom } from 'jotai/utils'
 
-import { documentAtom } from '@/store/atoms/document'
+import { ShapeRenderer } from '@/features/canvas/renderers/ShapeRenderer'
+import { documentAtom, shapeAtomsAtom } from '@/store/atoms/document'
 
 const CANVAS_SIZE = 512
 
+// viewBox is a fresh array on every atomWithImmer update; compare by value
+// so the stage doesn't re-render when other document fields change.
+const viewBoxAtom = selectAtom(
+  documentAtom,
+  (doc) => doc.viewBox,
+  (a, b) => a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3],
+)
+
 export function CanvasStage() {
-  const doc = useAtomValue(documentAtom)
-  const viewBox = doc.viewBox.join(' ')
+  const viewBox = useAtomValue(viewBoxAtom)
+  const shapeAtoms = useAtomValue(shapeAtomsAtom)
 
   return (
     <svg
       aria-label="Icon canvas"
       role="img"
-      viewBox={viewBox}
+      viewBox={viewBox.join(' ')}
       width={CANVAS_SIZE}
       height={CANVAS_SIZE}
       className="border-border bg-background block border"
-    />
+    >
+      {shapeAtoms.map((shapeAtom) => (
+        <ShapeRenderer key={String(shapeAtom)} shapeAtom={shapeAtom} />
+      ))}
+    </svg>
   )
 }

--- a/src/features/canvas/renderers/RectRenderer.tsx
+++ b/src/features/canvas/renderers/RectRenderer.tsx
@@ -1,0 +1,13 @@
+import type { RectShape } from '@/types/shapes'
+
+export function RectRenderer({ shape }: { shape: RectShape }) {
+  return (
+    <rect
+      x={shape.x}
+      y={shape.y}
+      width={shape.width}
+      height={shape.height}
+      fill={shape.fill ?? '#000'}
+    />
+  )
+}

--- a/src/features/canvas/renderers/ShapeRenderer.tsx
+++ b/src/features/canvas/renderers/ShapeRenderer.tsx
@@ -1,0 +1,19 @@
+import { type PrimitiveAtom, useAtomValue } from 'jotai'
+
+import { assertNever } from '@/lib/assertNever'
+import type { Shape } from '@/types/shapes'
+
+import { RectRenderer } from './RectRenderer'
+
+export function ShapeRenderer({ shapeAtom }: { shapeAtom: PrimitiveAtom<Shape> }) {
+  const shape = useAtomValue(shapeAtom)
+
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition -- exhaustive guard for future Shape variants */
+  switch (shape.type) {
+    case 'rect':
+      return <RectRenderer shape={shape} />
+    default:
+      return assertNever(shape.type)
+  }
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+}

--- a/src/lib/assertNever.ts
+++ b/src/lib/assertNever.ts
@@ -1,0 +1,3 @@
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled discriminated union member: ${JSON.stringify(value)}`)
+}

--- a/src/store/atoms/document.ts
+++ b/src/store/atoms/document.ts
@@ -1,10 +1,43 @@
+import { atom } from 'jotai'
+import { splitAtom } from 'jotai/utils'
 import { atomWithImmer } from 'jotai-immer'
 
-import { DEFAULT_VIEWBOX, type Document } from '@/types/shapes'
+import { DEFAULT_VIEWBOX, type Document, type Shape } from '@/types/shapes'
+
+// TRANSIENT SEED: a single hardcoded rect so the data-driven renderer has
+// something to show in this slice. Remove in the command-pipeline slice
+// once shapes can be added at runtime (see issue tracking that work).
+const SEED_SHAPES: Shape[] = [
+  {
+    id: 'seed-rect',
+    name: 'Rect 1',
+    visible: true,
+    locked: false,
+    type: 'rect',
+    x: 4,
+    y: 4,
+    width: 16,
+    height: 16,
+    fill: '#000',
+  },
+]
 
 export const documentAtom = atomWithImmer<Document>({
   id: 'doc-1',
   name: 'Untitled',
   viewBox: [...DEFAULT_VIEWBOX] as Document['viewBox'],
-  shapes: [],
+  shapes: SEED_SHAPES,
 })
+
+export const shapesAtom = atom(
+  (get) => get(documentAtom).shapes,
+  (_get, set, shapes: Shape[]) => {
+    set(documentAtom, (draft) => {
+      draft.shapes = shapes
+    })
+  },
+)
+
+export const shapeAtomsAtom = splitAtom(shapesAtom)
+
+export const shapeByIdAtom = atom((get) => new Map(get(shapesAtom).map((s) => [s.id, s])))

--- a/src/test/renderWithStore.tsx
+++ b/src/test/renderWithStore.tsx
@@ -1,0 +1,19 @@
+import { render, type RenderResult } from '@testing-library/react'
+import { createStore, Provider } from 'jotai'
+import type { ReactElement } from 'react'
+
+export type TestStore = ReturnType<typeof createStore>
+
+export interface RenderWithStoreResult extends RenderResult {
+  store: TestStore
+}
+
+export function renderWithStore(
+  ui: ReactElement,
+  seed?: (store: TestStore) => void,
+): RenderWithStoreResult {
+  const store = createStore()
+  seed?.(store)
+  const utils = render(<Provider store={store}>{ui}</Provider>)
+  return { ...utils, store }
+}


### PR DESCRIPTION
## Summary
- Canvas now subscribes via `splitAtom`-produced per-shape atoms so single-shape edits won't re-render siblings.
- New `ShapeRenderer` dispatches on the `Shape` discriminant with `assertNever`, plus a `RectRenderer` emitting `<svg:rect>`.
- Transient seed rect in `documentAtom` gives the renderer something to show until the command pipeline lands.

## Acceptance criteria
- [x] Derived atoms in `src/store/atoms/document.ts`: flat `shapesAtom`, `splitAtom`-produced `shapeAtomsAtom`, and `shapeByIdAtom` lookup map.
- [x] `assertNever(x: never): never` helper in `src/lib/assertNever.ts`.
- [x] `CanvasStage` maps `shapeAtomsAtom` to `ShapeRenderer`; switch on `shape.type` with `assertNever` default; `RectRenderer` emits `<rect>` with `x`, `y`, `width`, `height`, `fill`.
- [x] `documentAtom` seeded with a single hardcoded rect `{ x:4, y:4, width:16, height:16, fill:'#000' }`; TRANSIENT-SEED comment marks it for removal in the command-pipeline slice.
- [ ] Running `pnpm dev` shows a black 16×16 rect inside the bordered 512×512 canvas (not auto-verified — manual check).
- [x] Component test `CanvasStage.test.tsx` renders via `renderWithStore` with a seeded rect and asserts the `<rect>` attributes.
- [x] No direct `documentAtom` reads in render paths — `CanvasStage` reads a `selectAtom`-derived `viewBoxAtom` and `shapeAtomsAtom`; `ShapeRenderer` reads only its own per-shape atom.
- [x] `pnpm check` passes.

## Test plan
- `pnpm check` (tsc + eslint + prettier + vitest) — green.
- New unit tests in `src/features/canvas/CanvasStage.test.tsx` cover seed rendering, viewBox, and multi-shape rendering.
- Manual: `pnpm dev` and confirm the black 16×16 rect renders in the 512×512 canvas.

Closes #14