### PR TITLE
feat: command pipeline: createCommand + history stack + addShape + DevSidebar button

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwind-merge": "^3.5.0",
+    "ulid": "^3.0.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      ulid:
+        specifier: ^3.0.2
+        version: 3.0.2
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2146,6 +2149,10 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
     hasBin: true
 
   unbox-primitive@1.1.0:
@@ -4501,6 +4508,8 @@ snapshots:
       - supports-color
 
   typescript@6.0.3: {}
+
+  ulid@3.0.2: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/src/components/DevSidebar.tsx
+++ b/src/components/DevSidebar.tsx
@@ -1,11 +1,26 @@
+import { useSetAtom } from 'jotai'
+
+import { addShapeCommand } from '@/store/commands/addShape'
+
 // TRANSIENT: delete once real layers/properties/export panels land.
 export function DevSidebar() {
+  const addShape = useSetAtom(addShapeCommand)
+
   return (
     <aside
       aria-label="Dev sidebar (transient)"
-      className="bg-sidebar text-sidebar-foreground border-sidebar-border flex w-72 flex-col border-l p-4"
+      className="bg-sidebar text-sidebar-foreground border-sidebar-border flex w-72 flex-col gap-3 border-l p-4"
     >
       <p className="text-muted-foreground text-xs tracking-wide uppercase">Dev Sidebar</p>
+      <button
+        type="button"
+        onClick={() => {
+          addShape({ x: 4, y: 4, width: 16, height: 16, fill: '#000' })
+        }}
+        className="border-sidebar-border hover:bg-sidebar-accent rounded border px-3 py-1.5 text-sm"
+      >
+        Add Rect
+      </button>
     </aside>
   )
 }

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -1,0 +1,6 @@
+import { ulid } from 'ulid'
+
+// Wrapped so tests can swap in deterministic ids without a codemod.
+export function newId(): string {
+  return ulid()
+}

--- a/src/store/atoms/document.ts
+++ b/src/store/atoms/document.ts
@@ -4,29 +4,11 @@ import { atomWithImmer } from 'jotai-immer'
 
 import { DEFAULT_VIEWBOX, type Document, type Shape } from '@/types/shapes'
 
-// TRANSIENT SEED: a single hardcoded rect so the data-driven renderer has
-// something to show in this slice. Remove in the command-pipeline slice
-// once shapes can be added at runtime (see issue tracking that work).
-const SEED_SHAPES: Shape[] = [
-  {
-    id: 'seed-rect',
-    name: 'Rect 1',
-    visible: true,
-    locked: false,
-    type: 'rect',
-    x: 4,
-    y: 4,
-    width: 16,
-    height: 16,
-    fill: '#000',
-  },
-]
-
 export const documentAtom = atomWithImmer<Document>({
   id: 'doc-1',
   name: 'Untitled',
   viewBox: [...DEFAULT_VIEWBOX] as Document['viewBox'],
-  shapes: SEED_SHAPES,
+  shapes: [],
 })
 
 export const shapesAtom = atom(

--- a/src/store/atoms/history.ts
+++ b/src/store/atoms/history.ts
@@ -1,0 +1,15 @@
+import { atom } from 'jotai'
+
+import type { Document } from '@/types/shapes'
+
+export interface HistoryEntry {
+  label: string
+  before: Document
+  after: Document
+}
+
+export const undoStackAtom = atom<HistoryEntry[]>([])
+export const redoStackAtom = atom<HistoryEntry[]>([])
+
+export const canUndoAtom = atom((get) => get(undoStackAtom).length > 0)
+export const canRedoAtom = atom((get) => get(redoStackAtom).length > 0)

--- a/src/store/commands/addShape.test.ts
+++ b/src/store/commands/addShape.test.ts
@@ -1,0 +1,88 @@
+import { createStore } from 'jotai'
+import { describe, expect, it } from 'vitest'
+
+import { documentAtom } from '@/store/atoms/document'
+import { redoStackAtom, undoStackAtom } from '@/store/atoms/history'
+import type { Document } from '@/types/shapes'
+
+import { addShapeCommand } from './addShape'
+
+const emptyDoc: Document = {
+  id: 'doc-test',
+  name: 'Test',
+  viewBox: [0, 0, 24, 24],
+  shapes: [],
+}
+
+function makeStore(doc: Document = emptyDoc) {
+  const store = createStore()
+  store.set(documentAtom, doc)
+  return store
+}
+
+describe('addShapeCommand', () => {
+  it('appends a RectShape to the document', () => {
+    const store = makeStore()
+
+    store.set(addShapeCommand, { x: 4, y: 4, width: 16, height: 16, fill: '#000' })
+
+    const shapes = store.get(documentAtom).shapes
+    expect(shapes).toHaveLength(1)
+    expect(shapes[0]).toMatchObject({
+      type: 'rect',
+      x: 4,
+      y: 4,
+      width: 16,
+      height: 16,
+      fill: '#000',
+      name: 'Rect',
+      visible: true,
+      locked: false,
+    })
+    expect(shapes[0].id).toBeTypeOf('string')
+    expect(shapes[0].id.length).toBeGreaterThan(0)
+  })
+
+  it('assigns a unique id to each dispatched shape', () => {
+    const store = makeStore()
+
+    store.set(addShapeCommand, { x: 0, y: 0, width: 1, height: 1 })
+    store.set(addShapeCommand, { x: 0, y: 0, width: 1, height: 1 })
+
+    const [a, b] = store.get(documentAtom).shapes
+    expect(a.id).not.toBe(b.id)
+  })
+
+  it('pushes exactly one entry to the undo stack with the expected label', () => {
+    const store = makeStore()
+
+    store.set(addShapeCommand, { x: 4, y: 4, width: 16, height: 16, fill: '#000' })
+
+    const undo = store.get(undoStackAtom)
+    expect(undo).toHaveLength(1)
+    expect(undo[0].label).toBe('Add shape')
+    expect(undo[0].before.shapes).toHaveLength(0)
+    expect(undo[0].after.shapes).toHaveLength(1)
+  })
+
+  it('clears the redo stack on dispatch', () => {
+    const store = makeStore()
+    // simulate a prior redo-available state
+    store.set(redoStackAtom, [{ label: 'stale', before: emptyDoc, after: emptyDoc }])
+
+    store.set(addShapeCommand, { x: 0, y: 0, width: 1, height: 1 })
+
+    expect(store.get(redoStackAtom)).toEqual([])
+  })
+
+  it('does not mutate the prior document reference', () => {
+    const store = makeStore()
+    const before = store.get(documentAtom)
+
+    store.set(addShapeCommand, { x: 0, y: 0, width: 1, height: 1 })
+
+    const after = store.get(documentAtom)
+    expect(after).not.toBe(before)
+    expect(before.shapes).toHaveLength(0)
+  })
+})

--- a/src/store/commands/addShape.ts
+++ b/src/store/commands/addShape.ts
@@ -1,0 +1,23 @@
+import { newId } from '@/lib/ids'
+import type { RectShape } from '@/types/shapes'
+
+import { createCommand } from './createCommand'
+
+export type AddRectPayload = Omit<RectShape, 'id' | 'type' | 'name' | 'visible' | 'locked'> &
+  Partial<Pick<RectShape, 'name' | 'visible' | 'locked'>>
+
+export const addShapeCommand = createCommand<AddRectPayload>('Add shape', (doc, payload) => {
+  const shape: RectShape = {
+    ...payload,
+    id: newId(),
+    type: 'rect',
+    name: payload.name ?? 'Rect',
+    visible: payload.visible ?? true,
+    locked: payload.locked ?? false,
+  }
+
+  return {
+    ...doc,
+    shapes: [...doc.shapes, shape],
+  }
+})

--- a/src/store/commands/createCommand.test.ts
+++ b/src/store/commands/createCommand.test.ts
@@ -1,0 +1,63 @@
+import { createStore } from 'jotai'
+import { describe, expect, it } from 'vitest'
+
+import { documentAtom } from '@/store/atoms/document'
+import { redoStackAtom, undoStackAtom } from '@/store/atoms/history'
+import type { Document } from '@/types/shapes'
+
+import { createCommand } from './createCommand'
+
+const emptyDoc: Document = {
+  id: 'doc-test',
+  name: 'Test',
+  viewBox: [0, 0, 24, 24],
+  shapes: [],
+}
+
+function makeStore() {
+  const store = createStore()
+  store.set(documentAtom, emptyDoc)
+  return store
+}
+
+describe('createCommand', () => {
+  it('writes the next document and records a history entry on change', () => {
+    const renameCommand = createCommand<string>('Rename', (doc, name) => ({ ...doc, name }))
+    const store = makeStore()
+
+    store.set(renameCommand, 'Next')
+
+    expect(store.get(documentAtom).name).toBe('Next')
+    const undo = store.get(undoStackAtom)
+    expect(undo).toHaveLength(1)
+    expect(undo[0]).toMatchObject({
+      label: 'Rename',
+      before: { name: 'Test' },
+      after: { name: 'Next' },
+    })
+  })
+
+  it('short-circuits when apply returns the same reference', () => {
+    const noopCommand = createCommand<null>('Noop', (doc) => doc)
+    const store = makeStore()
+    const before = store.get(documentAtom)
+
+    store.set(noopCommand, null)
+
+    expect(store.get(documentAtom)).toBe(before)
+    expect(store.get(undoStackAtom)).toHaveLength(0)
+  })
+
+  it('clears the redo stack on every dispatch', () => {
+    const bumpCommand = createCommand<null>('Bump', (doc) => ({
+      ...doc,
+      name: `${doc.name}!`,
+    }))
+    const store = makeStore()
+    store.set(redoStackAtom, [{ label: 'stale', before: emptyDoc, after: emptyDoc }])
+
+    store.set(bumpCommand, null)
+
+    expect(store.get(redoStackAtom)).toEqual([])
+  })
+})

--- a/src/store/commands/createCommand.ts
+++ b/src/store/commands/createCommand.ts
@@ -1,0 +1,21 @@
+import { atom } from 'jotai'
+
+import { documentAtom } from '@/store/atoms/document'
+import { redoStackAtom, undoStackAtom } from '@/store/atoms/history'
+import type { Document } from '@/types/shapes'
+
+// Referential equality short-circuits keep no-op commands out of history.
+export function createCommand<Payload>(
+  label: string,
+  apply: (doc: Document, payload: Payload) => Document,
+) {
+  return atom(null, (get, set, payload: Payload) => {
+    const before = get(documentAtom)
+    const after = apply(before, payload)
+    if (after === before) return
+
+    set(documentAtom, after)
+    set(undoStackAtom, (stack) => [...stack, { label, before, after }])
+    set(redoStackAtom, [])
+  })
+}


### PR DESCRIPTION
## Summary
- Introduce `createCommand(label, apply)` factory — the single path every document mutation will flow through, with a referential-equality short-circuit and history-stack entry on change.
- Build the first concrete command (`addShapeCommand`) on top of it, backed by a `newId()` helper that wraps `ulid` as the single swap point for shape IDs.
- Wire a transient "Add Rect" button in `DevSidebar` and remove the hardcoded seed so the canvas starts empty and only populates via the command.

## Acceptance criteria
- [x] `newId()` utility exists (wrapping `ulid`) as the single import site for shape ID generation; `ulid` is added as a runtime dependency. — `src/lib/ids.ts`, `package.json`
- [x] History atoms defined in `src/store/atoms/history.ts`: `undoStackAtom`, `redoStackAtom`, derived `canUndoAtom`, `canRedoAtom`. Stack entries store `{ label, before, after }` document snapshots.
- [x] `createCommand(label, apply)` factory in `src/store/commands/createCommand.ts` returns a write-only atom that: reads doc, applies the pure function, short-circuits on referential equality, sets the doc, pushes a history entry, clears the redo stack. — covered by `createCommand.test.ts`
- [x] `addShapeCommand` in `src/store/commands/addShape.ts` accepts a partial rect payload, assigns `newId()`, and appends the resulting `RectShape` to `document.shapes`.
- [x] `DevSidebar` renders an "Add Rect" button that dispatches `addShapeCommand` with `{ x: 4, y: 4, width: 16, height: 16, fill: '#000' }`.
- [x] The hardcoded document seed from the previous slice is removed; the canvas starts empty and populates on button click. — `src/store/atoms/document.ts`
- [ ] `pnpm dev` + clicking "Add Rect" appends a visible rect and grows the undo stack by one entry per click; the redo stack remains empty (it is cleared on each dispatch). — requires manual verification in the running dev server
- [x] Command tests in `src/store/commands/addShape.test.ts`: dispatching `addShapeCommand` appends a shape to the document; the undo stack has exactly one entry with the expected label after one dispatch.
- [x] `pnpm check` passes.

## Test plan
- New unit tests: `src/store/commands/createCommand.test.ts` (factory contract: write on change, no-op short-circuit, redo-clear) and `src/store/commands/addShape.test.ts` (append, unique id per dispatch, undo entry, redo clear, no mutation).
- Manual: `pnpm dev`, click "Add Rect" several times, confirm a new rect appears in the canvas per click and Jotai DevTools shows `undoStackAtom` growing and `redoStackAtom` empty.

Closes #15