### PR TITLE
feat: button primitive fork (Pattern 3 canonical)

### DIFF
--- a/src/components/DevSidebar.tsx
+++ b/src/components/DevSidebar.tsx
@@ -15,7 +15,7 @@ export function DevSidebar() {
       <p className="text-muted-foreground text-xs tracking-wide uppercase">Dev Sidebar</p>
       <Button
         type="button"
-        variant="outline"
+        variant="default"
         size="sm"
         onClick={() => {
           addShape({ x: 4, y: 4, width: 16, height: 16, fill: '#000' })

--- a/src/components/primitives/Button.test.tsx
+++ b/src/components/primitives/Button.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Button, type ButtonSize, type ButtonVariant } from '@/components/primitives/Button'
+
+const VARIANTS: ButtonVariant[] = ['default', 'primary', 'ghost', 'destructive']
+const SIZES: ButtonSize[] = ['default', 'sm', 'xs', 'icon', 'icon-sm', 'icon-xs']
+
+describe('Button', () => {
+  it('renders as a <button> with default variant and size', () => {
+    render(<Button>Click</Button>)
+    const button = screen.getByRole('button', { name: 'Click' })
+    expect(button.tagName).toBe('BUTTON')
+    expect(button.getAttribute('data-variant')).toBe('default')
+    expect(button.getAttribute('data-size')).toBe('default')
+  })
+
+  describe.each(VARIANTS)('variant "%s"', (variant) => {
+    it('renders with the matching data-variant attribute', () => {
+      render(<Button variant={variant}>Label</Button>)
+      expect(screen.getByRole('button').getAttribute('data-variant')).toBe(variant)
+    })
+  })
+
+  describe.each(SIZES)('size "%s"', (size) => {
+    it('renders with the matching data-size attribute', () => {
+      render(<Button size={size} aria-label="Icon button" />)
+      expect(screen.getByRole('button').getAttribute('data-size')).toBe(size)
+    })
+  })
+
+  it('sets aria-pressed="true" when pressed is true', () => {
+    render(<Button pressed>Toggle</Button>)
+    expect(screen.getByRole('button').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('sets aria-pressed="false" when pressed is false', () => {
+    render(<Button pressed={false}>Toggle</Button>)
+    expect(screen.getByRole('button').getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('omits aria-pressed when pressed is undefined', () => {
+    render(<Button>Toggle</Button>)
+    expect(screen.getByRole('button').hasAttribute('aria-pressed')).toBe(false)
+  })
+
+  it('keys pressed-state styling off aria-pressed (aria-pressed:* utilities in base class list, unchanged by pressed)', () => {
+    const { rerender } = render(
+      <Button className="extra" pressed={false}>
+        Toggle
+      </Button>,
+    )
+    const notPressed = screen.getByRole('button').className
+    expect(notPressed).toContain('aria-pressed:bg-primary-muted')
+    rerender(
+      <Button className="extra" pressed>
+        Toggle
+      </Button>,
+    )
+    const pressed = screen.getByRole('button').className
+    expect(pressed).toContain('aria-pressed:bg-primary-muted')
+    expect(pressed).toBe(notPressed)
+  })
+
+  it('forwards props to a custom child element when asChild is set', () => {
+    render(
+      <Button asChild variant="primary">
+        <a href="/export">Export</a>
+      </Button>,
+    )
+    const link = screen.getByRole('link', { name: 'Export' })
+    expect(link.tagName).toBe('A')
+    expect(link.getAttribute('href')).toBe('/export')
+    expect(link.getAttribute('data-variant')).toBe('primary')
+    expect(link.getAttribute('data-slot')).toBe('button')
+  })
+
+  it('fires the click handler on user click', async () => {
+    const onClick = vi.fn()
+    render(<Button onClick={onClick}>Click</Button>)
+    await userEvent.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses the click handler when disabled', async () => {
+    const onClick = vi.fn()
+    render(
+      <Button disabled onClick={onClick}>
+        Click
+      </Button>,
+    )
+    await userEvent.click(screen.getByRole('button'))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('applies the active:scale-[0.97] press affordance in the base class list', () => {
+    render(<Button>Press</Button>)
+    expect(screen.getByRole('button').className).toContain('active:scale-[0.97]')
+  })
+})

--- a/src/components/primitives/Button.tsx
+++ b/src/components/primitives/Button.tsx
@@ -1,7 +1,91 @@
-// Pass-through wrapper for the shadcn Button primitive.
+// FORKED from @/components/ui/button at shadcn 2026-04-24.
 //
-// App code must import from here (not from @/components/ui/button) so that
-// when shadcn is re-generated, we only need to reconcile one file. Re-exports
-// are named (not `export *`) so react-refresh can statically see what leaves
-// this module.
-export { Button, buttonVariants } from '@/components/ui/button'
+// Pattern 3 canonical example (see docs/ui-primitives.md). The shadcn default
+// variant set is collapsed onto the DS vocabulary:
+//   shadcn `default` (bg-primary)     → our `primary`   (loud export action)
+//   shadcn `outline` (border+bg)      → our `default`   (quiet chrome)
+//   shadcn `ghost`/`destructive`       → kept
+//   shadcn `secondary`/`link`          → removed
+// The `pressed` prop surfaces toggle state via `aria-pressed`; pressed-state
+// styling is keyed off the DOM attribute via Tailwind's `aria-pressed:*`
+// variant, not via a conditional className — one source of truth for
+// accessibility and visual state.
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import { Slot } from 'radix-ui'
+import type { ComponentProps } from 'react'
+
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  [
+    'inline-flex shrink-0 items-center justify-center gap-2 rounded-md',
+    'text-sm font-medium whitespace-nowrap outline-none',
+    'transition-transform duration-150 ease-out active:scale-[0.97]',
+    'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+    'disabled:pointer-events-none disabled:opacity-50',
+    'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+    'aria-pressed:bg-primary-muted aria-pressed:border-primary aria-pressed:text-primary-subtle',
+    "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  ].join(' '),
+  {
+    variants: {
+      variant: {
+        default:
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        primary: 'bg-primary text-primary-foreground hover:bg-primary-hover',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        destructive:
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
+      },
+      size: {
+        default: 'h-7 px-3 has-[>svg]:px-2.5',
+        sm: 'h-6 gap-1.5 px-2.5 has-[>svg]:px-2',
+        xs: "h-5 gap-1 px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        icon: 'size-7',
+        'icon-sm': 'size-6',
+        'icon-xs': "size-5 [&_svg:not([class*='size-'])]:size-3",
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+type ButtonVariantProps = VariantProps<typeof buttonVariants>
+
+export type ButtonVariant = NonNullable<ButtonVariantProps['variant']>
+export type ButtonSize = NonNullable<ButtonVariantProps['size']>
+
+export type ButtonProps = Omit<ComponentProps<'button'>, 'aria-pressed'> &
+  ButtonVariantProps & {
+    asChild?: boolean
+    /** Toggle state. When defined, surfaces as `aria-pressed`; `true` also triggers the DS pressed styling. */
+    pressed?: boolean
+  }
+
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  pressed,
+  ...props
+}: ButtonProps) {
+  const Comp = asChild ? Slot.Root : 'button'
+
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      aria-pressed={pressed}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button }

--- a/src/index.css
+++ b/src/index.css
@@ -258,7 +258,7 @@
   }
 
   body {
-    @apply bg-background text-foreground font-sans text-base antialiased tabular-nums;
+    @apply bg-background text-foreground font-sans text-base tabular-nums antialiased;
   }
 }
 


### PR DESCRIPTION
## Summary
- Fork `src/components/ui/button.tsx` into `src/components/primitives/Button.tsx` as the canonical Pattern 3 example (see `docs/ui-primitives.md`).
- Collapse shadcn's variant set onto the DS vocabulary: `default` (quiet chrome) / `primary` (loud) / `ghost` / `destructive`. Sizes: `default` (h-7), `sm` (h-6), `xs` (h-5), `icon` / `icon-sm` / `icon-xs`.
- Add `pressed?: boolean` — surfaced as `aria-pressed`, with DS pressed-state styling keyed off the `aria-pressed:*` Tailwind variant so the DOM attribute is the single source of truth for accessibility and visual state.

## Acceptance criteria
- [x] `src/components/primitives/Button.tsx` exists, forked from `src/components/ui/button.tsx`, with the `// FORKED from …` header
- [x] Variant prop type exposes exactly `default | primary | ghost | destructive`
- [x] Size prop type exposes exactly `default | sm | xs | icon | icon-sm | icon-xs`
- [x] `pressed={true}` produces `aria-pressed="true"` on the rendered element
- [x] Pressed-state styling keys off the `aria-pressed` attribute (CSS selector, not conditional className)
- [x] `asChild` forwards props to a custom child element
- [x] `disabled` suppresses the click handler
- [x] `active:scale-[0.97]` is applied on press
- [x] Co-located `Button.test.tsx` covers each variant, each size, `pressed` → `aria-pressed`, `asChild`, `disabled`, click handler (14 cases)
- [x] `pnpm check` passes

## Test plan
- `src/components/primitives/Button.test.tsx` — 14 Vitest cases covering variant/size matrix, `pressed` semantics, `aria-pressed:*` base-class presence, `asChild` forwarding, click handler, `disabled`, press affordance.
- Manually verified `DevSidebar` still renders and "Add rect" fires (call-site migrated from removed `outline` → `default`).

Closes #28