### PR TITLE
feat: toggleGroup primitive (shadcn pass-through wrapper)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,10 +54,15 @@ export default defineConfig([
   {
     // shadcn-generated output. Treated as vendor code: do not reformat,
     // do not lint for react-refresh boundaries — it is regenerated verbatim.
+    // Sibling ui/ imports (e.g. toggle-group → toggle) and `||` chains come
+    // straight from shadcn; we can't rewrite them without breaking byte-for-
+    // byte regen parity.
     files: ['src/components/ui/**/*.{ts,tsx}'],
     rules: {
       'simple-import-sort/imports': 'off',
       'react-refresh/only-export-components': 'off',
+      'no-restricted-imports': 'off',
+      '@typescript-eslint/prefer-nullish-coalescing': 'off',
     },
   },
   {

--- a/src/components/primitives/ToggleGroup.tsx
+++ b/src/components/primitives/ToggleGroup.tsx
@@ -1,0 +1,6 @@
+// Pass-through wrapper for the shadcn ToggleGroup primitive (Pattern 1 — see
+// docs/ui-primitives.md). No behavior added; DS tokens in index.css retint it.
+//
+// Named re-exports (not `export *`) so react-refresh can statically see what
+// leaves this module.
+export { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Toggle as TogglePrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 min-w-9 px-2",
+        sm: "h-8 min-w-8 px-1.5",
+        lg: "h-10 min-w-10 px-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }


### PR DESCRIPTION
## Summary
- Vendor `toggle-group` (and its `toggle` sibling) via `pnpm dlx shadcn@latest add toggle-group` — byte-identical to CLI output.
- Add `src/components/primitives/ToggleGroup.tsx` as a Pattern 1 named re-export (`ToggleGroup`, `ToggleGroupItem`); DS tokens in `index.css` retint it without a wrapper.
- Widen the existing `src/components/ui/**` ESLint override with `no-restricted-imports: off` (vendor file uses `@/components/ui/toggle`) and `@typescript-eslint/prefer-nullish-coalescing: off` (shadcn emits `||` chains) — both needed to keep vendor regen byte-parity.

## Acceptance criteria
- [x] `src/components/ui/toggle-group.tsx` exists via shadcn CLI (byte-identical to vendor output)
- [x] `src/components/primitives/ToggleGroup.tsx` re-exports `ToggleGroup` and `ToggleGroupItem` from the vendor file
- [x] No hand edits to vendor files
- [x] `components.json` reflects the CLI addition (shadcn v2 does not write per-component entries; file presence under `src/components/ui/` is the reflection — `components.json` itself is unchanged)
- [x] `pnpm check` passes (ESLint allows the primitive's internal `@/components/ui/*` import)

## Test plan
- Pattern 1 wrappers add no behavior — no new tests per `docs/ui-primitives.md`.
- Verified `pnpm check` locally via `/implement-issue`.
- Manual: import `ToggleGroup`, `ToggleGroupItem` from `@/components/primitives/ToggleGroup`; ESLint `no-restricted-imports` still blocks `@/components/ui/toggle-group` from app code elsewhere.

Closes #29