### PR TITLE
feat: slider primitive (14px thumb override)

### DIFF
--- a/src/components/primitives/Slider.tsx
+++ b/src/components/primitives/Slider.tsx
@@ -1,0 +1,23 @@
+// Pattern 2 wrapper (see docs/ui-primitives.md): vendor defaults to a 16px
+// white thumb on a muted track; the DS calls for a 14px indigo thumb on
+// `--track`. Tokens come from the global layer — only sizing and slot-targeted
+// surfaces are restated here.
+
+import type { ComponentProps } from 'react'
+
+import { Slider as UISlider } from '@/components/ui/slider'
+import { cn } from '@/lib/utils'
+
+export function Slider({ className, ...props }: ComponentProps<typeof UISlider>) {
+  return (
+    <UISlider
+      className={cn(
+        '[&_[data-slot=slider-track]]:bg-track',
+        '[&_[data-slot=slider-thumb]]:size-3.5',
+        '[&_[data-slot=slider-thumb]]:bg-primary',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,61 @@
+import * as React from "react"
+import { Slider as SliderPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }


### PR DESCRIPTION
## Summary
- Add shadcn `slider` primitive via the CLI (vendored at `src/components/ui/slider.tsx`, unmodified).
- Wrap it as Pattern 2 at `src/components/primitives/Slider.tsx`: forward all props/refs, layer descendant-selector overrides for a 14px thumb on `--primary` and a `--track` surface. Tokens flow from the global layer.

## Acceptance criteria
- [x] `src/components/ui/slider.tsx` exists via shadcn CLI (unmodified)
- [x] `src/components/primitives/Slider.tsx` wraps the vendor Slider with a 14px thumb
- [x] Track surface uses the `--track` token
- [x] Thumb uses the `--primary` token (indigo)
- [x] All Slider props (value, onValueChange, min, max, step, disabled) forward through the wrapper
- [ ] `pnpm check` passes

## Test plan
- No new tests — wrapper is a pure visual override (per the issue scope).
- Manual: drop `<Slider />` from `@/components/primitives/Slider` into a story/page, verify 14px indigo thumb on the lighter `--track` rail in both themes.

Closes #30