### PR TITLE
feat: input primitive (monospace + tabular-nums chrome default)

### DIFF
--- a/src/components/primitives/Input.tsx
+++ b/src/components/primitives/Input.tsx
@@ -1,0 +1,13 @@
+// Pattern 2 wrapper (see docs/ui-primitives.md): the DS calls for monospace
+// + tabular numerics on numeric-leaning fields (grid size, rotation degrees,
+// …). Baking it in here means call-sites don't re-thread the same classes,
+// and callers can still override by passing their own `className`.
+
+import type { ComponentProps } from 'react'
+
+import { Input as UIInput } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+export function Input({ className, ...props }: ComponentProps<typeof UIInput>) {
+  return <UIInput className={cn('font-mono tabular-nums', className)} {...props} />
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }


### PR DESCRIPTION
## Summary
- Vendor shadcn's `input` primitive via the CLI (`src/components/ui/input.tsx`, unmodified).
- Add `src/components/primitives/Input.tsx` as a Pattern-2 composition wrapper that layers `font-mono tabular-nums` onto the base className via `cn`, keeping the full native input prop surface and ref forwarding intact.

## Acceptance criteria
- [x] `src/components/ui/input.tsx` exists via shadcn CLI (unmodified)
- [x] `src/components/primitives/Input.tsx` wraps the vendor Input with `font-mono tabular-nums` defaults
- [x] Custom className passed by consumer is merged via `cn` (not overwritten)
- [x] All native input props forward through the wrapper
- [x] Ref forwarding works
- [x] `pnpm check` passes

## Test plan
- No new tests: per `docs/ui-primitives.md`, Pattern-2 wrappers that only add visual defaults are not unit-tested.
- `pnpm check` green locally (tsc + eslint + prettier + vitest, 48 tests).
- Manual: render `<Input />` somewhere and confirm monospace + tabular-nums apply; pass a custom className and confirm it merges rather than overrides.

Closes #31