### PR TITLE
feat: segmented component (sliding pill)

### DIFF
--- a/src/components/Segmented.test.tsx
+++ b/src/components/Segmented.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Segmented, type SegmentedOption } from '@/components/Segmented'
+
+const UNIT_OPTIONS: SegmentedOption[] = [
+  { value: 'px', label: 'px' },
+  { value: '%', label: '%' },
+  { value: 'em', label: 'em' },
+]
+
+const noop = () => undefined
+
+function pill() {
+  const el = document.querySelector<HTMLElement>('[data-slot="segmented-pill"]')
+  if (!el) throw new Error('Segmented pill not found')
+  return el
+}
+
+describe('Segmented', () => {
+  it('fires onChange with the segment value when a segment is clicked', async () => {
+    const onChange = vi.fn()
+    render(<Segmented options={UNIT_OPTIONS} value="px" onChange={onChange} />)
+
+    await userEvent.click(screen.getByText('%'))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('%')
+  })
+
+  it('swallows Radix deselection when the active segment is re-clicked', async () => {
+    const onChange = vi.fn()
+    render(<Segmented options={UNIT_OPTIONS} value="px" onChange={onChange} />)
+
+    await userEvent.click(screen.getByText('px'))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('positions the pill at `left = activeIndex/count` and `width = 1/count`', () => {
+    const { rerender } = render(<Segmented options={UNIT_OPTIONS} value="px" onChange={noop} />)
+
+    const count = UNIT_OPTIONS.length
+    const pct = (index: number) => `${((index / count) * 100).toString()}%`
+
+    expect(pill().style.left).toBe(pct(0))
+    expect(pill().style.width).toBe(pct(1))
+
+    rerender(<Segmented options={UNIT_OPTIONS} value="%" onChange={noop} />)
+    expect(pill().style.left).toBe(pct(1))
+    expect(pill().style.width).toBe(pct(1))
+
+    rerender(<Segmented options={UNIT_OPTIONS} value="em" onChange={noop} />)
+    expect(pill().style.left).toBe(pct(2))
+    expect(pill().style.width).toBe(pct(1))
+  })
+
+  it('applies the `duration-200 ease-out` transition on the pill', () => {
+    render(<Segmented options={UNIT_OPTIONS} value="px" onChange={noop} />)
+    const className = pill().className
+    expect(className).toContain('duration-200')
+    expect(className).toContain('ease-out')
+  })
+
+  it('hides the pill when `value` is not in options', () => {
+    render(<Segmented options={UNIT_OPTIONS} value="rem" onChange={noop} />)
+    expect(pill().className).toContain('opacity-0')
+  })
+
+  it('selects the next segment via keyboard arrow navigation (inherited from ToggleGroup)', async () => {
+    const onChange = vi.fn()
+    render(<Segmented options={UNIT_OPTIONS} value="px" onChange={onChange} />)
+
+    // Roving focus: the active item is the tab-stop. Focus it, arrow-right
+    // moves focus, Space activates the newly focused item.
+    const active = screen.getByText('px').closest('button')
+    if (!active) throw new Error('Active segment button not found')
+    active.focus()
+
+    await userEvent.keyboard('{ArrowRight}')
+    await userEvent.keyboard(' ')
+
+    expect(onChange).toHaveBeenCalledWith('%')
+  })
+})

--- a/src/components/Segmented.tsx
+++ b/src/components/Segmented.tsx
@@ -1,0 +1,73 @@
+// The global `prefers-reduced-motion` rule in `src/index.css` collapses the
+// pill's transition duration to ~0ms without any per-component branch.
+
+import type { ReactNode } from 'react'
+
+import { ToggleGroup, ToggleGroupItem } from '@/components/primitives/ToggleGroup'
+import { cn } from '@/lib/utils'
+
+export type SegmentedOption = {
+  value: string
+  label: ReactNode
+}
+
+export type SegmentedProps = {
+  options: SegmentedOption[]
+  value: string
+  onChange: (value: string) => void
+  className?: string
+  'aria-label'?: string
+}
+
+export function Segmented({
+  options,
+  value,
+  onChange,
+  className,
+  'aria-label': ariaLabel,
+}: SegmentedProps) {
+  const count = options.length
+  const activeIndex = options.findIndex((option) => option.value === value)
+  const pillLeft = ((Math.max(activeIndex, 0) / count) * 100).toString()
+  const pillWidth = ((1 / count) * 100).toString()
+
+  return (
+    <ToggleGroup
+      type="single"
+      value={value}
+      onValueChange={(next) => {
+        // Radix fires "" when the user re-clicks the active segment. A
+        // segmented control shouldn't allow deselection — swallow that case.
+        if (next) onChange(next)
+      }}
+      aria-label={ariaLabel}
+      className={cn(
+        'bg-secondary text-muted-foreground relative grid w-full auto-cols-fr grid-flow-col gap-0 rounded-md p-0.5',
+        className,
+      )}
+    >
+      <span
+        aria-hidden
+        data-slot="segmented-pill"
+        className={cn(
+          'bg-background text-foreground pointer-events-none absolute inset-y-0.5 rounded-[5px] shadow-xs',
+          'transition-[left,width] duration-200 ease-out',
+          activeIndex < 0 && 'opacity-0',
+        )}
+        style={{ left: `${pillLeft}%`, width: `${pillWidth}%` }}
+      />
+      {options.map((option) => (
+        <ToggleGroupItem
+          key={option.value}
+          value={option.value}
+          className={cn(
+            'relative z-10 h-7 w-full min-w-0 bg-transparent px-3 text-sm',
+            'data-[state=on]:text-foreground data-[state=on]:bg-transparent',
+          )}
+        >
+          {option.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}


### PR DESCRIPTION
## Summary
- New `src/components/Segmented.tsx` — app-level animated segmented control composing the `ToggleGroup` primitive.
- Layers an absolutely-positioned sliding pill with `left`/`width` inline styles derived from the active index; transitions `duration-200 ease-out`.
- `prefers-reduced-motion` is handled globally via `src/index.css`, so no per-component branch is needed.

## Acceptance criteria
- [x] `src/components/Segmented.tsx` composes the `ToggleGroup` primitive
- [x] An absolutely-positioned sliding pill element is rendered inside the group
- [x] Pill `left` and `width` inline styles are derived from `value`'s position in `options`
- [x] Pill transition uses `duration-200 ease-out`
- [x] Clicking a segment fires `onChange` with the correct value
- [x] Co-located tests cover callback on click, pill position style for active index, and keyboard navigation
- [x] `pnpm check` passes

## Test plan
- New `src/components/Segmented.test.tsx` — 6 Vitest cases: click → onChange, deselection swallowed, pill `left`/`width` for each active index (3 rerenders), `duration-200 ease-out` classes present, pill hidden when `value` not in options, keyboard arrow + Space selects next segment.
- `pnpm check` green locally (tsc + eslint + prettier + vitest; 54 tests).
- Manual: drop `<Segmented options={…} value={…} onChange={…} />` into a page, watch the pill slide when clicking segments and when using Tab → ArrowRight → Space.

Closes #34