### PR TITLE
feat: brandmark component

### DIFF
--- a/src/components/BrandMark.test.tsx
+++ b/src/components/BrandMark.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { BrandMark } from '@/components/BrandMark'
+
+function mark() {
+  const el = document.querySelector<SVGSVGElement>('[data-slot="brand-mark"]')
+  if (!el) throw new Error('BrandMark element not found')
+  return el
+}
+
+describe('BrandMark', () => {
+  it('defaults `size` to 16 and maps it onto width and height', () => {
+    render(<BrandMark />)
+    const el = mark()
+    expect(el.getAttribute('width')).toBe('16')
+    expect(el.getAttribute('height')).toBe('16')
+  })
+
+  it('maps `size` onto both width and height on the SVG', () => {
+    render(<BrandMark size={64} />)
+    const el = mark()
+    expect(el.getAttribute('width')).toBe('64')
+    expect(el.getAttribute('height')).toBe('64')
+  })
+
+  it('contains the two nested-square `<rect>` children from the DS spec', () => {
+    render(<BrandMark />)
+    const rects = mark().querySelectorAll('rect')
+    expect(rects).toHaveLength(2)
+  })
+
+  it('uses `currentColor` for every fill so the mark inherits the surrounding color', () => {
+    render(<BrandMark />)
+    const rects = mark().querySelectorAll('rect')
+    for (const rect of rects) {
+      expect(rect.getAttribute('fill')).toBe('currentColor')
+    }
+  })
+})

--- a/src/components/BrandMark.tsx
+++ b/src/components/BrandMark.tsx
@@ -1,0 +1,26 @@
+// Nested-square brand logo from the DS (see `docs/design-system.html`, section
+// "Brand mark"). Rendered as inline SVG so it scales crisp at any size and
+// inherits color from the surrounding text via `currentColor`. The outer frame
+// sits at 20% opacity; the inner canvas is solid.
+
+import type { ComponentProps } from 'react'
+
+export type BrandMarkProps = ComponentProps<'svg'> & {
+  size?: number
+}
+
+export function BrandMark({ size = 16, ...props }: BrandMarkProps) {
+  return (
+    <svg
+      {...props}
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      data-slot="brand-mark"
+    >
+      <rect x="1" y="1" width="14" height="14" rx="3" fill="currentColor" opacity="0.2" />
+      <rect x="4" y="4" width="8" height="8" rx="1.5" fill="currentColor" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- New `src/components/BrandMark.tsx` rendering the DS nested-square logo as inline SVG.
- `size` prop (default 16) maps onto both `width` and `height`; fills use `currentColor` so the mark inherits the surrounding text color.
- Intended for header, favicons, and the future about-screen.

## Acceptance criteria
- [x] `src/components/BrandMark.tsx` renders the DS nested-square logo via inline SVG
- [x] `size` prop (default 16) maps to both `width` and `height` on the SVG
- [x] Fill uses `currentColor`
- [x] Co-located tests cover default size, explicit size, and rect count
- [x] `pnpm check` passes

## Test plan
- `src/components/BrandMark.test.tsx` covers: default-size mapping, explicit-size mapping, two-rect structure, and `currentColor` on every fill.
- Manual: drop `<BrandMark />` into the DS playground and confirm it renders identically to the `docs/design-system.html` "Brand mark" section at 16px, 32px, 64px.

Closes #33